### PR TITLE
feat(WC2): Add Wallet Connect 2 to Provider Types

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1573,6 +1573,8 @@ export enum ProviderType {
     // (undocumented)
     WALLET_CONNECT = "wallet_connect",
     // (undocumented)
+    WALLET_CONNECT_V2 = "wallet_connect_v2",
+    // (undocumented)
     WALLET_LINK = "wallet_link"
 }
 

--- a/src/dapps/provider-type.ts
+++ b/src/dapps/provider-type.ts
@@ -14,7 +14,7 @@ export enum ProviderType {
   NETWORK = 'network',
   WALLET_CONNECT = 'wallet_connect',
   WALLET_CONNECT_V2 = 'wallet_connect_v2',
-  WALLET_LINK = 'wallet_link'
+  WALLET_LINK = 'wallet_link',
   METAMASK_MOBILE = 'metamask_mobile'
 }
 

--- a/src/dapps/provider-type.ts
+++ b/src/dapps/provider-type.ts
@@ -13,6 +13,7 @@ export enum ProviderType {
   FORTMATIC = 'formatic',
   NETWORK = 'network',
   WALLET_CONNECT = 'wallet_connect',
+  WALLET_CONNECT_V2 = 'wallet_connect_v2',
   WALLET_LINK = 'wallet_link'
 }
 


### PR DESCRIPTION
Add `WALLET_CONNECT_V2` to start supporting this new provider on the different dapps.

[decentraland-connect](https://github.com/decentraland/decentraland-connect) will instantiate the WalletConnectV2 connector when this provider is received.