### PR TITLE
feat: add rental days filter to rental listings

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1161,6 +1161,7 @@ export type NFTFilters = {
     minDistanceToPlaza?: number;
     maxDistanceToPlaza?: number;
     adjacentToRoad?: boolean;
+    rentalDays: number[];
 } & Pick<RentalsListingsFilterBy, 'tenant'>;
 
 // Warning: (ae-missing-release-tag) "NFTSortBy" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1707,6 +1708,7 @@ export type RentalsListingsFilterBy = {
     minEstateSize?: number;
     maxEstateSize?: number;
     adjacentToRoad?: boolean;
+    rentalDays: number[];
 };
 
 // Warning: (ae-missing-release-tag) "RentalsListingsFilterByCategory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2306,10 +2308,10 @@ export namespace WorldConfiguration {
 // src/dapps/preview/preview-message.ts:39:9 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
 // src/dapps/preview/preview-message.ts:73:9 - (ae-forgotten-export) The symbol "EmoteEventPayload" needs to be exported by the entry point index.d.ts
 // src/dapps/rentals-listings.ts:89:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/dapps/rentals-listings.ts:128:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/dapps/rentals-listings.ts:130:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
-// src/dapps/rentals-listings.ts:180:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/dapps/rentals-listings.ts:182:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
+// src/dapps/rentals-listings.ts:130:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/rentals-listings.ts:132:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
+// src/dapps/rentals-listings.ts:182:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/rentals-listings.ts:184:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/sale.ts:22:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/sale.ts:23:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/sale.ts:46:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1161,7 +1161,7 @@ export type NFTFilters = {
     minDistanceToPlaza?: number;
     maxDistanceToPlaza?: number;
     adjacentToRoad?: boolean;
-    rentalDays: number[];
+    rentalDays?: number[];
 } & Pick<RentalsListingsFilterBy, 'tenant'>;
 
 // Warning: (ae-missing-release-tag) "NFTSortBy" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1708,7 +1708,7 @@ export type RentalsListingsFilterBy = {
     minEstateSize?: number;
     maxEstateSize?: number;
     adjacentToRoad?: boolean;
-    rentalDays: number[];
+    rentalDays?: number[];
 };
 
 // Warning: (ae-missing-release-tag) "RentalsListingsFilterByCategory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/dapps/nft.ts
+++ b/src/dapps/nft.ts
@@ -102,8 +102,10 @@ export type NFTFilters = {
   minDistanceToPlaza?: number
   /** Filter NFTs with at most this distance to a plaza */
   maxDistanceToPlaza?: number
-  /** Filter that are next to a road */
+  /** Filter NFTs that are next to a road */
   adjacentToRoad?: boolean
+  /** Filter rentals that have periods that include any of the rental days */
+  rentalDays?: number[]
 } & Pick<RentalsListingsFilterBy, 'tenant'>
 
 export enum NFTSortBy {

--- a/src/dapps/nft.ts
+++ b/src/dapps/nft.ts
@@ -104,7 +104,7 @@ export type NFTFilters = {
   maxDistanceToPlaza?: number
   /** Filter NFTs that are next to a road */
   adjacentToRoad?: boolean
-  /** Filter rentals that have periods that include any of the rental days */
+  /** Filter NFTs by rentals that have periods that include any of the rental days */
   rentalDays?: number[]
 } & Pick<RentalsListingsFilterBy, 'tenant'>
 

--- a/src/dapps/rentals-listings.ts
+++ b/src/dapps/rentals-listings.ts
@@ -110,6 +110,8 @@ export type RentalsListingsFilterBy = {
   maxEstateSize?: number
   /** If true, it will fetch all parcels and estates that are next to a road */
   adjacentToRoad?: boolean
+  /** The days that a rental should be available */
+  rentalDays?: number[]
 }
 
 /**


### PR DESCRIPTION
Add new possible filter to rental listings: `rentalDays`. This is an array of numbers that represent which amount of days a listing should be available to rent

