### PR TITLE
fix: restore support to allow base wearables deployment

### DIFF
--- a/src/platform/item/base-item.ts
+++ b/src/platform/item/base-item.ts
@@ -57,3 +57,15 @@ export const requiredBaseItemProps = [
   'thumbnail',
   'image'
 ] as const
+
+export function isBaseAvatar(item: BaseItem): boolean {
+  if (!item || !item.id) {
+    return false
+  }
+
+  const urnParts = item.id.split(':')
+  const isDecentralandAvatar = urnParts[1] === 'decentraland'
+  const isBaseAvatar = urnParts[3] === 'base-avatars'
+
+  return urnParts.length === 5 && isDecentralandAvatar && isBaseAvatar
+}

--- a/src/platform/item/wearable/wearable.ts
+++ b/src/platform/item/wearable/wearable.ts
@@ -4,6 +4,7 @@ import { WearableRepresentation } from './representation'
 import {
   BaseItem,
   baseItemProperties,
+  isBaseAvatar,
   requiredBaseItemProps
 } from '../base-item'
 import { StandardProps, standardProperties } from '../standard-props'
@@ -61,24 +62,29 @@ export namespace Wearable {
       }
     },
     additionalProperties: true,
-    required: [...requiredBaseItemProps, 'data'],
+    required: [],
     oneOf: [
       {
-        required: ['collectionAddress', 'rarity'],
+        required: ['id', 'i18n'],
+        prohibited: ['merkleProof', 'content', 'collectionAddress', 'rarity'],
+        _isBaseAvatar: true
+      },
+      {
+        required: [
+          ...requiredBaseItemProps,
+          'data',
+          'collectionAddress',
+          'rarity'
+        ],
         prohibited: ['merkleProof', 'content']
       },
       {
         required: [
+          ...requiredBaseItemProps,
+          'data',
           'merkleProof',
           /* MerkleProof emote required Keys (might be redundant) */
-          'content',
-          'id',
-          'name',
-          'description',
-          'i18n',
-          'image',
-          'thumbnail',
-          'data'
+          'content'
         ],
         prohibited: ['collectionAddress', 'rarity'],
         _isThirdParty: true
@@ -95,6 +101,12 @@ export namespace Wearable {
     errors: false
   }
 
+  const _isBaseAvatarKeywordDef = {
+    keyword: '_isBaseAvatar',
+    validate: (schema: boolean, data: any) => !schema || isBaseAvatar(data),
+    errors: false
+  }
+
   /**
    * Validates that the wearable metadata complies with the standard or third party wearable, and doesn't have repeated locales.
    * Some fields are defined as optional but those are validated to be present as standard XOR third party:
@@ -106,6 +118,7 @@ export namespace Wearable {
    *    - content
    */
   export const validate = generateLazyValidator(schema, [
-    _isThirdPartyKeywordDef
+    _isThirdPartyKeywordDef,
+    _isBaseAvatarKeywordDef
   ])
 }

--- a/test/platform/item/wearable/wearable.spec.ts
+++ b/test/platform/item/wearable/wearable.spec.ts
@@ -95,6 +95,15 @@ describe('Wearable representation tests', () => {
   testTypeSignature(Wearable, wearable)
   testTypeSignature(Wearable, thirdPartyWearable)
 
+  it('static base wearable must puss', () => {
+    expect(
+      Wearable.validate({
+        ...baseWearable,
+        id: 'urn:decentraland:off-chain:base-avatars:basemale'
+      })
+    ).toEqual(true)
+  })
+
   it('static tests must pass', () => {
     expect(Wearable.validate(wearable)).toEqual(true)
     expect(Wearable.validate(null)).toEqual(false)
@@ -146,12 +155,6 @@ describe('Wearable representation tests', () => {
       { ...baseWearable, ...standard, ...thirdParty },
       ['either standard XOR thirdparty properties conditions must be met']
     )
-  })
-
-  it('wearable should be standard and/or thirdparty', () => {
-    expectValidationFailureWithErrors(Wearable.validate, baseWearable, [
-      'either standard XOR thirdparty properties conditions must be met'
-    ])
   })
 
   it('wearable cannot be both standard and thirdparty', () => {


### PR DESCRIPTION
This PR modifies the AJV validations for wearables and base items so base avatars can be deployed without all the current required properties.

Current behavior:
* We check if a wearable is base by splitting the URN and validating the different fields

Ideal behavior:
* Check if a wearable is base using urn-parser
  * This is still pending since urn-parser is async and all our validations are sync at the moment, we need to refactor the current validators and ensure that the clients won't suffer side-effects after it (modify all the clients if needed) 