### PR TITLE
fix: update links url regex

### DIFF
--- a/src/platform/profile/avatar.ts
+++ b/src/platform/profile/avatar.ts
@@ -122,7 +122,7 @@ export type LinkUrl = string
 export namespace LinkUrl {
   export const schema: JSONSchema<LinkUrl> = {
     type: 'string',
-    pattern: '^((https?:)?\\/\\/)?([\\da-z.-]+)\\.([a-z.]{2,6})([\\/\\w.-]*)*\\/?$' // RFC-3986: Uniform Resource Identifier (URI): Generic Syntax // Parsing a URI Reference with a Regular Expression
+    pattern: '^((https?:)?\\/\\/)?([\\da-z.-]+)\\.([a-z.]{2,6})([\\/\\w .%()\\-]*)*\\/?$' // RFC-3986: Uniform Resource Identifier (URI): Generic Syntax // Parsing a URI Reference with a Regular Expression
   }
   const regexp = new RegExp(schema.pattern!, 'i')
   export const validate: ValidateFunction<LinkUrl> = (url: any): url is LinkUrl => regexp.test(url)


### PR DESCRIPTION
In order to support special characters, we have updated the regex for links' urls from this:
```
^((https?:)?\\/\\/)?([\\da-z.-]+)\\.([a-z.]{2,6})([\\/\\w.-]*)*\\/?$
```

To this new one:
```
^((https?:)?\\/\\/)?([\\da-z.-]+)\\.([a-z.]{2,6})([\\/\\w .%()\\-]*)*\\/?$
```