### PR TITLE
feat: Add urn field to dapps Item and NFT types

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -899,6 +899,7 @@ export type Item = {
     data: NFT['data'];
     network: Network;
     chainId: ChainId;
+    urn: string;
     firstListedAt: number | null;
     picks?: {
         pickedByUser?: boolean;
@@ -1210,6 +1211,7 @@ export type NFT = {
     createdAt: number;
     updatedAt: number;
     soldAt: number;
+    urn?: string;
 };
 
 // @public (undocumented)
@@ -2474,7 +2476,7 @@ export namespace WorldConfiguration {
 // src/dapps/contract.ts:16:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/item.ts:30:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/item.ts:31:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
-// src/dapps/item.ts:68:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/item.ts:69:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/mint.ts:16:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/mint.ts:17:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/mint.ts:37:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
@@ -2482,7 +2484,7 @@ export namespace WorldConfiguration {
 // src/dapps/nft.ts:54:7 - (ae-incompatible-release-tags) The symbol "bodyShapes" is marked as @public, but its signature references "BodyShape" which is marked as @alpha
 // src/dapps/nft.ts:58:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/nft.ts:59:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
-// src/dapps/nft.ts:88:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/nft.ts:89:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/order.ts:18:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/order.ts:19:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/order.ts:33:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha

--- a/src/dapps/item.ts
+++ b/src/dapps/item.ts
@@ -29,6 +29,7 @@ export type Item = {
   data: NFT['data']
   network: Network
   chainId: ChainId
+  urn: string
   /** The timestamp in seconds since epoch when the item was listed for sale for the first time */
   firstListedAt: number | null
   picks?: {
@@ -131,6 +132,9 @@ export namespace Item {
       data: NFT.schema.properties!.data,
       network: Network.schema,
       chainId: ChainId.schema,
+      urn: {
+        type: 'string'
+      },
       createdAt: {
         type: 'integer'
       },

--- a/src/dapps/nft.ts
+++ b/src/dapps/nft.ts
@@ -60,6 +60,7 @@ export type NFT = {
   createdAt: number
   updatedAt: number
   soldAt: number
+  urn?: string
 }
 
 export type NFTFilters = {
@@ -282,6 +283,10 @@ export namespace NFT {
       },
       soldAt: {
         type: 'integer'
+      },
+      urn: {
+        type: 'string',
+        nullable: true
       }
     },
     required: [

--- a/test/dapps/item.spec.ts
+++ b/test/dapps/item.spec.ts
@@ -34,7 +34,8 @@ describe('Item tests', () => {
       updatedAt: 1626088534000,
       reviewedAt: 1626088534000,
       soldAt: 1626088534000,
-      firstListedAt: null
+      firstListedAt: null,
+      urn: 'urn:decentraland:matic:collections-v2:0x0699189ac32c8e404d900786317c93c23fe6f209:0'
     }
 
     testTypeSignature(Item, wearable)


### PR DESCRIPTION
This PR adds the field: `urn` to the dapps `Item` and `NFT` types