### PR TITLE
feat: Add the LinkerAuthorization validator

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -991,6 +991,30 @@ export namespace Link {
     schema: JSONSchema<Link>;
 }
 
+// Warning: (ae-missing-release-tag) "LinkerAuthorization" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type LinkerAuthorization = {
+    name: string;
+    desc: string;
+    startDate?: number;
+    endDate?: number;
+    contactInfo: {
+        name: string;
+        [key: string]: string;
+    };
+    addresses: string[];
+    plots: string[];
+};
+
+// @public (undocumented)
+export namespace LinkerAuthorization {
+    const // (undocumented)
+    schema: JSONSchema<LinkerAuthorization>;
+    const // (undocumented)
+    validate: ValidateFunction<LinkerAuthorization>;
+}
+
 // @alpha
 export type LinkUrl = string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export { World, ValidWorldRange, getWorld, isInsideWorldLimits } from './dapps/w
 export * from './dapps/preview'
 export * from './platform'
 export * from './misc'
+export * from './misc/linker-authorization'
 export * from './misc/auth-chain'
 export * from './misc/content-mapping'
 export { sdk }

--- a/src/misc/linker-authorization.ts
+++ b/src/misc/linker-authorization.ts
@@ -1,0 +1,51 @@
+import { JSONSchema, ValidateFunction, generateLazyValidator } from '../validation'
+
+/**
+ * Represents a Linker-Server Authorization.
+ *
+ * @public
+ */
+export type LinkerAuthorization = {
+  name: string
+  desc: string
+  startDate?: number
+  endDate?: number
+  contactInfo: {
+    name: string
+    [key: string]: string
+  }
+  addresses: string[]
+  plots: string[]
+}
+
+export namespace LinkerAuthorization {
+  export const schema: JSONSchema<LinkerAuthorization> = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      desc: { type: 'string' },
+      startDate: { type: 'number', nullable: true },
+      endDate: { type: 'number', nullable: true },
+      contactInfo: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' }
+        },
+        required: ['name']
+      },
+      addresses: {
+        type: 'array',
+        items: { type: 'string' },
+        minItems: 1
+      },
+      plots: {
+        type: 'array',
+        items: { type: 'string' },
+        minItems: 1
+      }
+    },
+    required: ['name', 'desc', 'contactInfo', 'addresses', 'plots']
+  }
+
+  export const validate: ValidateFunction<LinkerAuthorization> = generateLazyValidator(schema)
+}

--- a/test/misc/linker-authorization.spec.ts
+++ b/test/misc/linker-authorization.spec.ts
@@ -1,0 +1,139 @@
+import expect from 'expect'
+import { LinkerAuthorization } from '../../src'
+
+describe('when validation authorizations', () => {
+  describe('and the authorization does not include a name', () => {
+    it('should return false', () => {
+      expect(
+        LinkerAuthorization.validate({
+          desc: 'aDesc',
+          contactInfo: {
+            name: 'aContactInfoName'
+          },
+          addresses: ['0x4730182099bc4e60075C657cCeCEc8879826bb43'],
+          plots: ['-73,50']
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('and the authorization does not include a description', () => {
+    it('should return false', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          contactInfo: {
+            name: 'aContactInfoName'
+          },
+          addresses: ['0x4730182099bc4e60075C657cCeCEc8879826bb43'],
+          plots: ['-73,50']
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('and the authorization does not include the contact information', () => {
+    it('should return false', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          desc: 'aDesc',
+          addresses: ['0x4730182099bc4e60075C657cCeCEc8879826bb43'],
+          plots: ['-73,50']
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('and the authorization contains an empty contact information', () => {
+    it('should return false', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          desc: 'aDesc',
+          contactInfo: {},
+          addresses: ['0x4730182099bc4e60075C657cCeCEc8879826bb43'],
+          plots: ['-73,50']
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('and the authorization does not include the addresses', () => {
+    it('should return false', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          desc: 'aDesc',
+          contactInfo: {
+            name: 'aContactInfoName'
+          },
+          plots: ['-73,50']
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('and the authorization contains an empty list of addresses', () => {
+    it('should return false', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          desc: 'aDesc',
+          contactInfo: {
+            name: 'aContactInfoName'
+          },
+          addresses: [],
+          plots: ['-73,50']
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('and the authorization does not include the plots', () => {
+    it('should return false', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          desc: 'aDesc',
+          contactInfo: {
+            name: 'aContactInfoName'
+          },
+          addresses: ['0x4730182099bc4e60075C657cCeCEc8879826bb43']
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('and the authorization contains an empty list of plots', () => {
+    it('should return false', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          desc: 'aDesc',
+          contactInfo: {
+            name: 'aContactInfoName'
+          },
+          addresses: ['0x4730182099bc4e60075C657cCeCEc8879826bb43'],
+          plots: []
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('and the authorization is formatted accordingly', () => {
+    it('should return true', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          desc: 'aDesc',
+          contactInfo: {
+            name: 'aContactInfoName'
+          },
+          addresses: ['0x4730182099bc4e60075C657cCeCEc8879826bb43'],
+          plots: ['-73,50']
+        })
+      ).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the LinkerAuthorization type to validate and use in the linker server and the linker server authorization's repo.