### PR TITLE
BREAKING: Change the profile URL validation regex

### DIFF
--- a/src/platform/profile/avatar.ts
+++ b/src/platform/profile/avatar.ts
@@ -123,7 +123,7 @@ export namespace LinkUrl {
   export const schema: JSONSchema<LinkUrl> = {
     type: 'string',
     maxLength: 2083,
-    pattern: '^(?:https?):\\/\\/[^\\s/$.?#].[^\\s]*$'
+    pattern: '^(?!javascript)[^\\s/$.?#].[^\\s]*$'
   }
   const regexp = new RegExp(schema.pattern!, 'i')
   export const validate: ValidateFunction<LinkUrl> = (url: any): url is LinkUrl => regexp.test(url)

--- a/src/platform/profile/avatar.ts
+++ b/src/platform/profile/avatar.ts
@@ -123,7 +123,7 @@ export namespace LinkUrl {
   export const schema: JSONSchema<LinkUrl> = {
     type: 'string',
     maxLength: 2083,
-    pattern: '^(?!javascript)[^\\s/$.?#].[^\\s]*$'
+    pattern: '^(?:https?):\\/\\/[^\\s/$.?#].[^\\s]*$'
   }
   const regexp = new RegExp(schema.pattern!, 'i')
   export const validate: ValidateFunction<LinkUrl> = (url: any): url is LinkUrl => regexp.test(url)

--- a/src/platform/profile/avatar.ts
+++ b/src/platform/profile/avatar.ts
@@ -122,7 +122,8 @@ export type LinkUrl = string
 export namespace LinkUrl {
   export const schema: JSONSchema<LinkUrl> = {
     type: 'string',
-    pattern: '^[(http(s)?):\\/\\/(www\\.)?a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$'
+    maxLength: 2083,
+    pattern: '^(?:https?):\\/\\/[^\\s/$.?#].[^\\s]*$'
   }
   const regexp = new RegExp(schema.pattern!, 'i')
   export const validate: ValidateFunction<LinkUrl> = (url: any): url is LinkUrl => regexp.test(url)

--- a/test/platform/profiles/avatar.spec.ts
+++ b/test/platform/profiles/avatar.spec.ts
@@ -89,4 +89,54 @@ describe('Avatar tests', () => {
     const avatar: Avatar = { ...AVATAR, ethAddress: 'someInvalidAddress' }
     expect(Avatar.validate(avatar)).toEqual(false)
   })
+
+  describe('when the avatar contains links that have query parameters', () => {
+    it('should return false', () => {
+      const avatar: Avatar = {
+        ...AVATAR,
+        links: [{ title: 'Invalid Link', url: 'https://alink.com?aVar=aValue&anotherVar=anotherValue' }]
+      }
+      expect(Avatar.validate(avatar)).toEqual(true)
+    })
+  })
+
+  describe('when the avatar contains links with url encoded characters', () => {
+    it('should return true', () => {
+      const avatar: Avatar = {
+        ...AVATAR,
+        links: [{ title: 'Link', url: 'https://alink.com?someVar=some%20value' }]
+      }
+      expect(Avatar.validate(avatar)).toEqual(true)
+    })
+  })
+
+  describe('when the avatar contains links that are of the https protocol', () => {
+    it('should return true', () => {
+      const avatar: Avatar = {
+        ...AVATAR,
+        links: [{ title: 'Link', url: 'https://alink.com' }]
+      }
+      expect(Avatar.validate(avatar)).toEqual(true)
+    })
+  })
+
+  describe('when the avatar contains links that are of the http protocol', () => {
+    it('should return true', () => {
+      const avatar: Avatar = {
+        ...AVATAR,
+        links: [{ title: 'Link', url: 'http://alink.com' }]
+      }
+      expect(Avatar.validate(avatar)).toEqual(true)
+    })
+  })
+
+  describe("when the avatar contains links that point to a protocol that's not http", () => {
+    it('should return false', () => {
+      const avatar: Avatar = {
+        ...AVATAR,
+        links: [{ title: 'Invalid Link', url: 'javascript:window%5b%22ale%22%2b%22rt%22%5d(document.domain)//.com' }]
+      }
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
 })

--- a/test/platform/profiles/avatar.spec.ts
+++ b/test/platform/profiles/avatar.spec.ts
@@ -130,7 +130,7 @@ describe('Avatar tests', () => {
     })
   })
 
-  describe("when the avatar contains links that point to a protocol that's not http", () => {
+  describe("when the avatar contains links that point to a protocol that's javascript", () => {
     it('should return false', () => {
       const avatar: Avatar = {
         ...AVATAR,

--- a/test/platform/profiles/avatar.spec.ts
+++ b/test/platform/profiles/avatar.spec.ts
@@ -130,7 +130,7 @@ describe('Avatar tests', () => {
     })
   })
 
-  describe("when the avatar contains links that point to a protocol that's javascript", () => {
+  describe("when the avatar contains links that point to a protocol that's not http", () => {
     it('should return false', () => {
       const avatar: Avatar = {
         ...AVATAR,


### PR DESCRIPTION
Force the profile Links to start with `http` or `https` in their profiles.
This PR implies a breaking change from the older regex which allowed other protocols to be set as link.