### PR TITLE
feat: add blockVrmExport property to wearables

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -2402,6 +2402,7 @@ export type Wearable = BaseItem & {
         representations: WearableRepresentation[];
         category: WearableCategory;
         removesDefaultHiding?: HideableWearableCategory[];
+        blockVrmExport?: boolean;
     };
 } & (StandardProps | ThirdPartyProps);
 

--- a/src/platform/item/wearable/wearable.ts
+++ b/src/platform/item/wearable/wearable.ts
@@ -15,6 +15,7 @@ export type Wearable = BaseItem & {
     representations: WearableRepresentation[]
     category: WearableCategory
     removesDefaultHiding?: HideableWearableCategory[]
+    blockVrmExport?: boolean
   }
 } & (StandardProps | ThirdPartyProps)
 
@@ -54,6 +55,10 @@ export namespace Wearable {
             type: 'array',
             nullable: true,
             items: HideableWearableCategory.schema
+          },
+          blockVrmExport: {
+            type: 'boolean',
+            nullable: true
           }
         },
         required: ['replaces', 'hides', 'tags', 'representations', 'category']

--- a/src/sdk/project/wearable-json.ts
+++ b/src/sdk/project/wearable-json.ts
@@ -57,6 +57,10 @@ export namespace WearableJson {
             type: 'array',
             nullable: true,
             items: HideableWearableCategory.schema
+          },
+          blockVrmExport: {
+            type: 'boolean',
+            nullable: true
           }
         },
         required: ['replaces', 'hides', 'tags', 'representations', 'category']

--- a/test/platform/item/wearable/wearable.spec.ts
+++ b/test/platform/item/wearable/wearable.spec.ts
@@ -23,7 +23,8 @@ describe('Wearable representation tests', () => {
       hides: [WearableCategory.EYEBROWS, BodyPartCategory.HANDS],
       tags: ['tag1'],
       representations: [representation],
-      category: WearableCategory.UPPER_BODY
+      category: WearableCategory.UPPER_BODY,
+      blockVrmExport: false
     },
     i18n: [
       {
@@ -90,6 +91,12 @@ describe('Wearable representation tests', () => {
     expect(Wearable.validate(wearable)).toEqual(true)
     expect(Wearable.validate(null)).toEqual(false)
     expect(Wearable.validate({})).toEqual(false)
+  })
+
+  it('should validate wearable without blockVrmExport', () => {
+    const wearableExport = { ...wearable }
+    delete (wearableExport.data as Wearable['data']).blockVrmExport
+    expect(Wearable.validate(wearableExport)).toEqual(true)
   })
 
   it('static tests must return the correct errors when missing properties', () => {


### PR DESCRIPTION
Add `blockVrmExport` property to wearable metadata