### PR TITLE
fix: Mappings schema validation

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -7,6 +7,7 @@
 import Ajv from 'ajv';
 import type { Emitter } from 'mitt';
 import { ErrorObject } from 'ajv';
+import { FuncKeywordDefinition } from 'ajv';
 import { JSONSchemaType } from 'ajv';
 import { KeywordDefinition } from 'ajv';
 
@@ -1424,11 +1425,7 @@ export type Mappings = Partial<Record<ContractNetwork, Record<ContractAddress, M
 // @alpha
 export namespace Mappings {
     const // (undocumented)
-    _isMappingsValid: {
-        keyword: string;
-        validate: (schema: boolean, data: any) => boolean;
-        errors: boolean;
-    };
+    _isMappingsValid: FuncKeywordDefinition;
     const // (undocumented)
     innerSchema: JSONSchema<Record<ContractAddress, Mapping[]>>;
     const // (undocumented)
@@ -3387,12 +3384,12 @@ export namespace WorldConfiguration {
 // src/platform/events/blockchain.ts:21:3 - (ae-forgotten-export) The symbol "BidMetadata" needs to be exported by the entry point index.d.ts
 // src/platform/events/blockchain.ts:163:3 - (ae-forgotten-export) The symbol "RentalMetadata" needs to be exported by the entry point index.d.ts
 // src/platform/item/emote/adr74/emote-data-adr74.ts:7:3 - (ae-incompatible-release-tags) The symbol "representations" is marked as @public, but its signature references "EmoteRepresentationADR74" which is marked as @alpha
-// src/platform/item/linked-wearable-mappings.ts:253:3 - (ae-incompatible-release-tags) The symbol "getMappings" is marked as @public, but its signature references "Mappings" which is marked as @alpha
-// src/platform/item/linked-wearable-mappings.ts:254:3 - (ae-incompatible-release-tags) The symbol "addMapping" is marked as @public, but its signature references "ContractNetwork" which is marked as @alpha
-// src/platform/item/linked-wearable-mappings.ts:254:3 - (ae-incompatible-release-tags) The symbol "addMapping" is marked as @public, but its signature references "ContractAddress" which is marked as @alpha
-// src/platform/item/linked-wearable-mappings.ts:254:3 - (ae-incompatible-release-tags) The symbol "addMapping" is marked as @public, but its signature references "Mapping" which is marked as @alpha
-// src/platform/item/linked-wearable-mappings.ts:255:3 - (ae-incompatible-release-tags) The symbol "includesNft" is marked as @public, but its signature references "ContractNetwork" which is marked as @alpha
-// src/platform/item/linked-wearable-mappings.ts:255:3 - (ae-incompatible-release-tags) The symbol "includesNft" is marked as @public, but its signature references "ContractAddress" which is marked as @alpha
+// src/platform/item/linked-wearable-mappings.ts:252:3 - (ae-incompatible-release-tags) The symbol "getMappings" is marked as @public, but its signature references "Mappings" which is marked as @alpha
+// src/platform/item/linked-wearable-mappings.ts:253:3 - (ae-incompatible-release-tags) The symbol "addMapping" is marked as @public, but its signature references "ContractNetwork" which is marked as @alpha
+// src/platform/item/linked-wearable-mappings.ts:253:3 - (ae-incompatible-release-tags) The symbol "addMapping" is marked as @public, but its signature references "ContractAddress" which is marked as @alpha
+// src/platform/item/linked-wearable-mappings.ts:253:3 - (ae-incompatible-release-tags) The symbol "addMapping" is marked as @public, but its signature references "Mapping" which is marked as @alpha
+// src/platform/item/linked-wearable-mappings.ts:254:3 - (ae-incompatible-release-tags) The symbol "includesNft" is marked as @public, but its signature references "ContractNetwork" which is marked as @alpha
+// src/platform/item/linked-wearable-mappings.ts:254:3 - (ae-incompatible-release-tags) The symbol "includesNft" is marked as @public, but its signature references "ContractAddress" which is marked as @alpha
 // src/platform/item/third-party-props.ts:7:3 - (ae-incompatible-release-tags) The symbol "merkleProof" is marked as @public, but its signature references "MerkleProof" which is marked as @alpha
 // src/platform/item/third-party-props.ts:9:3 - (ae-incompatible-release-tags) The symbol "mappings" is marked as @public, but its signature references "Mappings" which is marked as @alpha
 // src/platform/scene/feature-toggles.ts:11:3 - (ae-forgotten-export) The symbol "EnabledDisabled" needs to be exported by the entry point index.d.ts

--- a/src/platform/item/linked-wearable-mappings.ts
+++ b/src/platform/item/linked-wearable-mappings.ts
@@ -1,6 +1,5 @@
 import { generateLazyValidator, JSONSchema, ValidateFunction } from '../../validation'
-import { KeywordDefinition } from 'ajv'
-import { ThirdPartyProps } from './third-party-props'
+import { FuncKeywordDefinition, KeywordDefinition } from 'ajv'
 
 /**
  * MappingType
@@ -203,17 +202,17 @@ export namespace Mapping {
  * @alpha
  */
 export namespace Mappings {
-  export const _isMappingsValid = {
+  export const _isMappingsValid: FuncKeywordDefinition = {
     keyword: '_isMappingsValid',
-    validate: function (schema: boolean, data: any) {
-      const itemAsThirdParty = data as ThirdPartyProps
+    validate: function (data: Mappings) {
       try {
-        createMappingsHelper(itemAsThirdParty.mappings)
+        createMappingsHelper(data)
       } catch (_) {
         return false
       }
       return true
     },
+    schema: false,
     errors: false
   }
 
@@ -227,8 +226,7 @@ export namespace Mappings {
     },
     minProperties: 1,
     required: [],
-    additionalProperties: false,
-    _isMappingsValid: true
+    additionalProperties: false
   }
 
   const properties = Object.values(ContractNetwork).reduce((acc, network) => {
@@ -240,7 +238,8 @@ export namespace Mappings {
     type: 'object',
     properties,
     minProperties: 1,
-    additionalProperties: false
+    additionalProperties: false,
+    _isMappingsValid: true
   }
 
   export const validate: ValidateFunction<Mappings> = generateLazyValidator(schema, [

--- a/test/platform/item/linked-wearable-mappings.spec.ts
+++ b/test/platform/item/linked-wearable-mappings.spec.ts
@@ -50,6 +50,18 @@ describe('Third Party Mappings tests', () => {
     expect(Mappings.validate(mappings)).toEqual(true)
     expect(Mappings.validate(null)).toEqual(false)
     expectValidationFailureWithErrors(Mappings.validate, {}, ['must NOT have fewer than 1 properties'])
+    expectValidationFailureWithErrors(
+      Mappings.validate,
+      {
+        amoy: {
+          '0x1d9fb685c257E74f869BA302e260C0b68f5eBB37': [
+            { type: MappingType.ANY },
+            { type: MappingType.SINGLE, id: '0' }
+          ]
+        }
+      },
+      ['must pass "_isMappingsValid" keyword validation']
+    )
   })
 })
 


### PR DESCRIPTION
This PR fixes the validation of the Mappings schema by moving it up from the mappings properties to the mappings schema, which includes the networks in the data that is going to be validated.