### PR TITLE
feat: Add only dev option on linker authorizations

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1524,6 +1524,7 @@ export type LinkerAuthorization = {
         name: string;
         [key: string]: string;
     };
+    onlyDev?: boolean;
     addresses: string[];
     plots: string[];
 };

--- a/src/misc/linker-authorization.ts
+++ b/src/misc/linker-authorization.ts
@@ -14,6 +14,7 @@ export type LinkerAuthorization = {
     name: string
     [key: string]: string
   }
+  onlyDev?: boolean
   addresses: string[]
   plots: string[]
 }
@@ -33,6 +34,7 @@ export namespace LinkerAuthorization {
         },
         required: ['name']
       },
+      onlyDev: { type: 'boolean', nullable: true },
       addresses: {
         type: 'array',
         items: { type: 'string' },

--- a/test/misc/linker-authorization.spec.ts
+++ b/test/misc/linker-authorization.spec.ts
@@ -136,4 +136,21 @@ describe('when validation authorizations', () => {
       ).toBe(true)
     })
   })
+
+  describe('and the authorization has the onlyDev property set as a boolean', () => {
+    it('should return true', () => {
+      expect(
+        LinkerAuthorization.validate({
+          name: 'aName',
+          desc: 'aDesc',
+          contactInfo: {
+            name: 'aContactInfoName'
+          },
+          addresses: ['0x4730182099bc4e60075C657cCeCEc8879826bb43'],
+          plots: ['-73,50'],
+          onlyDev: true
+        })
+      ).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
This PR adds the `onlyDev` flag to identify authorizations that must be used only in development enviroments.