### PR TITLE
feat: timestamps property in client events (reportedAt and receivedAt)

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -3966,7 +3966,7 @@ export namespace WorldConfiguration {
 // src/dapps/trade.ts:91:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/trade.ts:92:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/platform/events/blockchain.ts:169:3 - (ae-forgotten-export) The symbol "RentalMetadata" needs to be exported by the entry point index.d.ts
-// src/platform/events/client.ts:16:3 - (ae-forgotten-export) The symbol "ClientBaseMetadata" needs to be exported by the entry point index.d.ts
+// src/platform/events/client.ts:31:3 - (ae-forgotten-export) The symbol "ClientBaseMetadata" needs to be exported by the entry point index.d.ts
 // src/platform/item/emote/adr74/emote-data-adr74.ts:7:3 - (ae-incompatible-release-tags) The symbol "representations" is marked as @public, but its signature references "EmoteRepresentationADR74" which is marked as @alpha
 // src/platform/item/linked-wearable-mappings.ts:251:3 - (ae-incompatible-release-tags) The symbol "getMappings" is marked as @public, but its signature references "Mappings" which is marked as @alpha
 // src/platform/item/linked-wearable-mappings.ts:252:3 - (ae-incompatible-release-tags) The symbol "addMapping" is marked as @public, but its signature references "ContractNetwork" which is marked as @alpha

--- a/src/platform/events/client.ts
+++ b/src/platform/events/client.ts
@@ -4,7 +4,22 @@ import { BaseEvent, Events } from './base'
 
 type ClientBaseMetadata = {
   authChain: AuthChain
+  /** @deprecated Use timestamps.reportedAt or timestamps.receivedAt instead */
   timestamp: number
+  timestamps: {
+    /**
+     * Timestamp when the event was reported by the client
+     *
+     * @type {number}
+     */
+    reportedAt: number
+    /**
+     * Timestamp when the event was received by the tracking system (e.g. Segment)
+     *
+     * @type {number}
+     */
+    receivedAt: number
+  }
   userAddress: EthAddress
   sessionId: string
   realm: string


### PR DESCRIPTION
This PR modifies all events being reported by client to:
* Mark current `metadata.timestamp` as deprecated
* Add new `metadata.timestamps` property containing `reportedAt` and `receivedAt` properties showcasing when the event was reported by the client and when it was received by Segment