### PR TITLE
feat: expose notification event for credits

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -934,7 +934,7 @@ export type CreditsGoalCompletedEvent = BaseEvent & {
         creditsObtained: number;
         seasonId: number;
         weekNumber: number;
-        userAddress: EthAddress;
+        address: EthAddress;
     };
 };
 

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1188,7 +1188,7 @@ export namespace EthAddress {
 // Warning: (ae-missing-release-tag) "Event" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type Event = BadgeGrantedEvent | BidAcceptedEvent | BidReceivedEvent | CampaignGasPriceHigherThanExpectedEvent | CampaignOutOfFundsEvent | CampaignOutOfStockEvent | CatalystDeploymentEvent | CollectionCreatedEvent | FriendshipRequestEvent | FriendshipAcceptedEvent | ItemPublishedEvent | ItemSoldEvent | MoveToParcelEvent | PassportOpenedEvent | RentalEndedEvent | RentalStartedEvent | RewardAssignedEvent | RewardDelayedEvent | RewardInProgressEvent | RoyaltiesEarnedEvent | UsedEmoteEvent | VerticalHeightReachedEvent | WalkedDistanceEvent;
+export type Event = BadgeGrantedEvent | BidAcceptedEvent | BidReceivedEvent | CampaignGasPriceHigherThanExpectedEvent | CampaignOutOfFundsEvent | CampaignOutOfStockEvent | CatalystDeploymentEvent | CollectionCreatedEvent | FriendshipRequestEvent | FriendshipAcceptedEvent | ItemPublishedEvent | ItemSoldEvent | MoveToParcelEvent | PassportOpenedEvent | RentalEndedEvent | RentalStartedEvent | RewardAssignedEvent | RewardDelayedEvent | RewardInProgressEvent | RoyaltiesEarnedEvent | UsedEmoteEvent | VerticalHeightReachedEvent | WalkedDistanceEvent | CreditsGoalCompletedEvent;
 
 // Warning: (ae-missing-release-tag) "Events" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -359,7 +359,7 @@ export type BaseBid = {
 // @public (undocumented)
 export type BaseEvent = {
     type: Events.Type;
-    subType: Events.SubType.Blockchain | Events.SubType.CatalystDeployment | Events.SubType.Client | Events.SubType.Marketplace | Events.SubType.Rewards | Events.SubType.Badge | Events.SubType.AssetBundle | Events.SubType.SocialService;
+    subType: Events.SubType.Blockchain | Events.SubType.CatalystDeployment | Events.SubType.Client | Events.SubType.Marketplace | Events.SubType.Rewards | Events.SubType.Badge | Events.SubType.AssetBundle | Events.SubType.SocialService | Events.SubType.CreditsService;
     key: string;
     timestamp: number;
 };
@@ -922,6 +922,28 @@ export enum ContractSortBy {
 // @public (undocumented)
 export function createMappingsHelper(initial?: Mappings): MappingsHelper;
 
+// Warning: (ae-missing-release-tag) "CreditsGoalCompletedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CreditsGoalCompletedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CreditsGoalCompletedEvent = BaseEvent & {
+    type: Events.Type.CREDITS_SERVICE;
+    subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED;
+    metadata: {
+        goalId: string;
+        goalTitle: string;
+        creditsAmount: number;
+    };
+};
+
+// @public (undocumented)
+export namespace CreditsGoalCompletedEvent {
+    const // (undocumented)
+    schema: JSONSchema<CreditsGoalCompletedEvent>;
+    const // (undocumented)
+    validate: ValidateFunction<CreditsGoalCompletedEvent>;
+}
+
 // Warning: (tsdoc-missing-deprecation-message) The @deprecated block must include a deprecation message, e.g. describing the recommended alternative
 //
 // @public @deprecated
@@ -1231,6 +1253,11 @@ export namespace Events {
             WALKED_DISTANCE = "walked-distance"
         }
         // (undocumented)
+        export enum CreditsService {
+            // (undocumented)
+            CREDITS_GOAL_COMPLETED = "credits-goal-completed"
+        }
+        // (undocumented)
         export enum Marketplace {
             // (undocumented)
             BID_RECEIVED = "bid-received"
@@ -1275,6 +1302,8 @@ export namespace Events {
         CATALYST_DEPLOYMENT = "catalyst-deployment",
         // (undocumented)
         CLIENT = "client",
+        // (undocumented)
+        CREDITS_SERVICE = "credits-service",
         // (undocumented)
         MARKETPLACE = "marketplace",
         // (undocumented)

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -931,8 +931,9 @@ export type CreditsGoalCompletedEvent = BaseEvent & {
     subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED;
     metadata: {
         goalId: string;
-        goalTitle: string;
-        creditsAmount: number;
+        creditsObtained: number;
+        seasonId: number;
+        weekNumber: number;
     };
 };
 
@@ -2275,6 +2276,8 @@ export enum NotificationType {
     BID_ACCEPTED = "bid_accepted",
     // (undocumented)
     BID_RECEIVED = "bid_received",
+    // (undocumented)
+    CREDITS_GOAL_COMPLETED = "credits_goal_completed",
     // (undocumented)
     EVENTS_STARTED = "events_started",
     // (undocumented)

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -934,6 +934,7 @@ export type CreditsGoalCompletedEvent = BaseEvent & {
         creditsObtained: number;
         seasonId: number;
         weekNumber: number;
+        userAddress: EthAddress;
     };
 };
 

--- a/src/platform/events/base.ts
+++ b/src/platform/events/base.ts
@@ -36,7 +36,8 @@ export namespace Events {
     REWARDS = 'rewards',
     BADGE = 'badge',
     ASSET_BUNDLE = 'asset-bundle',
-    SOCIAL_SERVICE = 'social-service'
+    SOCIAL_SERVICE = 'social-service',
+    CREDITS_SERVICE = 'credits-service'
   }
 
   export namespace SubType {
@@ -97,6 +98,10 @@ export namespace Events {
       FRIENDSHIP_REQUEST = 'friendship-request',
       FRIENDSHIP_ACCEPTED = 'friendship-accepted'
     }
+
+    export enum CreditsService {
+      CREDITS_GOAL_COMPLETED = 'credits-goal-completed'
+    }
   }
 }
 
@@ -111,6 +116,7 @@ export type BaseEvent = {
     | Events.SubType.Badge
     | Events.SubType.AssetBundle
     | Events.SubType.SocialService
+    | Events.SubType.CreditsService
   key: string
   timestamp: number
 }

--- a/src/platform/events/base.ts
+++ b/src/platform/events/base.ts
@@ -24,7 +24,12 @@ import {
   CampaignOutOfStockEvent,
   RewardDelayedEvent
 } from './rewards'
-import { BadgeGrantedEvent, FriendshipAcceptedEvent, FriendshipRequestEvent } from './services'
+import {
+  BadgeGrantedEvent,
+  CreditsGoalCompletedEvent,
+  FriendshipAcceptedEvent,
+  FriendshipRequestEvent
+} from './services'
 
 export namespace Events {
   export enum Type {
@@ -145,3 +150,4 @@ export type Event =
   | UsedEmoteEvent
   | VerticalHeightReachedEvent
   | WalkedDistanceEvent
+  | CreditsGoalCompletedEvent

--- a/src/platform/events/services.ts
+++ b/src/platform/events/services.ts
@@ -248,7 +248,6 @@ export type CreditsGoalCompletedEvent = BaseEvent & {
   subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED
   metadata: {
     goalId: string
-    goalTitle: string
     creditsAmount: number
   }
 }
@@ -265,10 +264,9 @@ export namespace CreditsGoalCompletedEvent {
         type: 'object',
         properties: {
           goalId: { type: 'string' },
-          goalTitle: { type: 'string' },
           creditsAmount: { type: 'number', minimum: 0 }
         },
-        required: ['goalId', 'goalTitle', 'creditsAmount']
+        required: ['goalId', 'creditsAmount']
       }
     },
     required: ['type', 'subType', 'key', 'timestamp', 'metadata'],

--- a/src/platform/events/services.ts
+++ b/src/platform/events/services.ts
@@ -248,7 +248,9 @@ export type CreditsGoalCompletedEvent = BaseEvent & {
   subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED
   metadata: {
     goalId: string
-    creditsAmount: number
+    creditsObtained: number
+    seasonId: number
+    weekNumber: number
   }
 }
 
@@ -264,9 +266,11 @@ export namespace CreditsGoalCompletedEvent {
         type: 'object',
         properties: {
           goalId: { type: 'string' },
-          creditsAmount: { type: 'number', minimum: 0 }
+          creditsObtained: { type: 'number', minimum: 0 },
+          seasonId: { type: 'number', minimum: 1 },
+          weekNumber: { type: 'number', minimum: 1 }
         },
-        required: ['goalId', 'creditsAmount']
+        required: ['goalId', 'creditsObtained', 'seasonId', 'weekNumber']
       }
     },
     required: ['type', 'subType', 'key', 'timestamp', 'metadata'],

--- a/src/platform/events/services.ts
+++ b/src/platform/events/services.ts
@@ -242,3 +242,38 @@ export namespace FriendshipAcceptedEvent {
 
   export const validate: ValidateFunction<FriendshipAcceptedEvent> = generateLazyValidator(schema)
 }
+
+export type CreditsGoalCompletedEvent = BaseEvent & {
+  type: Events.Type.CREDITS_SERVICE
+  subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED
+  metadata: {
+    goalId: string
+    goalTitle: string
+    creditsAmount: number
+  }
+}
+
+export namespace CreditsGoalCompletedEvent {
+  export const schema: JSONSchema<CreditsGoalCompletedEvent> = {
+    type: 'object',
+    properties: {
+      type: { type: 'string', const: Events.Type.CREDITS_SERVICE },
+      subType: { type: 'string', const: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED },
+      key: { type: 'string' },
+      timestamp: { type: 'number', minimum: 0 },
+      metadata: {
+        type: 'object',
+        properties: {
+          goalId: { type: 'string' },
+          goalTitle: { type: 'string' },
+          creditsAmount: { type: 'number', minimum: 0 }
+        },
+        required: ['goalId', 'goalTitle', 'creditsAmount']
+      }
+    },
+    required: ['type', 'subType', 'key', 'timestamp', 'metadata'],
+    additionalProperties: true
+  }
+
+  export const validate: ValidateFunction<CreditsGoalCompletedEvent> = generateLazyValidator(schema)
+}

--- a/src/platform/events/services.ts
+++ b/src/platform/events/services.ts
@@ -252,7 +252,7 @@ export type CreditsGoalCompletedEvent = BaseEvent & {
     creditsObtained: number
     seasonId: number
     weekNumber: number
-    userAddress: EthAddress
+    address: EthAddress
   }
 }
 
@@ -271,9 +271,9 @@ export namespace CreditsGoalCompletedEvent {
           creditsObtained: { type: 'number', minimum: 0 },
           seasonId: { type: 'number', minimum: 1 },
           weekNumber: { type: 'number', minimum: 1 },
-          userAddress: { type: 'string' }
+          address: { type: 'string' }
         },
-        required: ['goalId', 'creditsObtained', 'seasonId', 'weekNumber', 'userAddress']
+        required: ['goalId', 'creditsObtained', 'seasonId', 'weekNumber', 'address']
       }
     },
     required: ['type', 'subType', 'key', 'timestamp', 'metadata'],

--- a/src/platform/events/services.ts
+++ b/src/platform/events/services.ts
@@ -1,3 +1,4 @@
+import { EthAddress } from '../../misc'
 import { generateLazyValidator, JSONSchema, ValidateFunction } from '../../validation'
 import { BaseEvent, Events } from './base'
 
@@ -251,6 +252,7 @@ export type CreditsGoalCompletedEvent = BaseEvent & {
     creditsObtained: number
     seasonId: number
     weekNumber: number
+    userAddress: EthAddress
   }
 }
 
@@ -268,9 +270,10 @@ export namespace CreditsGoalCompletedEvent {
           goalId: { type: 'string' },
           creditsObtained: { type: 'number', minimum: 0 },
           seasonId: { type: 'number', minimum: 1 },
-          weekNumber: { type: 'number', minimum: 1 }
+          weekNumber: { type: 'number', minimum: 1 },
+          userAddress: { type: 'string' }
         },
-        required: ['goalId', 'creditsObtained', 'seasonId', 'weekNumber']
+        required: ['goalId', 'creditsObtained', 'seasonId', 'weekNumber', 'userAddress']
       }
     },
     required: ['type', 'subType', 'key', 'timestamp', 'metadata'],

--- a/src/platform/notifications/notifications.ts
+++ b/src/platform/notifications/notifications.ts
@@ -37,7 +37,8 @@ export enum NotificationType {
   WORLDS_ACCESS_RESTRICTED = 'worlds_access_restricted',
   WORLDS_MISSING_RESOURCES = 'worlds_missing_resources',
   WORLDS_PERMISSION_GRANTED = 'worlds_permission_granted',
-  WORLDS_PERMISSION_REVOKED = 'worlds_permission_revoked'
+  WORLDS_PERMISSION_REVOKED = 'worlds_permission_revoked',
+  CREDITS_GOAL_COMPLETED = 'credits_goal_completed'
 }
 
 /**

--- a/test/platform/events/credits.spec.ts
+++ b/test/platform/events/credits.spec.ts
@@ -10,7 +10,6 @@ describe('CreditsGoalCompleted Events tests', () => {
       timestamp: 1,
       metadata: {
         goalId: 'baf',
-        goalTitle: 'mac',
         creditsAmount: 1
       }
     }
@@ -30,7 +29,6 @@ describe('CreditsGoalCompletedEvent Events tests', () => {
       timestamp: 1,
       metadata: {
         goalId: 'baf',
-        goalTitle: 'mac',
         creditsAmount: 1
       }
     }

--- a/test/platform/events/credits.spec.ts
+++ b/test/platform/events/credits.spec.ts
@@ -13,7 +13,7 @@ describe('Credits Events tests', () => {
         creditsObtained: 100,
         seasonId: 1,
         weekNumber: 3,
-        userAddress: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
+        address: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
       }
     }
 
@@ -33,7 +33,7 @@ describe('Credits Events tests', () => {
         creditsObtained: -1, // Invalid negative amount
         seasonId: 1,
         weekNumber: 3,
-        userAddress: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
+        address: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
       }
     }
 
@@ -51,7 +51,7 @@ describe('Credits Events tests', () => {
         creditsObtained: 100,
         seasonId: 0, // Invalid season number
         weekNumber: 3,
-        userAddress: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
+        address: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
       }
     }
 
@@ -69,7 +69,7 @@ describe('Credits Events tests', () => {
         creditsObtained: 100,
         seasonId: 1,
         weekNumber: 0, // Invalid week number
-        userAddress: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
+        address: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
       }
     }
 

--- a/test/platform/events/credits.spec.ts
+++ b/test/platform/events/credits.spec.ts
@@ -1,16 +1,18 @@
 import expect from 'expect'
 import { CreditsGoalCompletedEvent, Events } from '../../../src'
 
-describe('CreditsGoalCompleted Events tests', () => {
+describe('Credits Events tests', () => {
   it('CreditsGoalCompletedEvent static tests must pass', () => {
     const event: CreditsGoalCompletedEvent = {
       type: Events.Type.CREDITS_SERVICE,
       subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED,
-      key: 'key',
-      timestamp: 1,
+      key: 'goal-completion-123',
+      timestamp: 1710234567890,
       metadata: {
-        goalId: 'baf',
-        creditsAmount: 1
+        goalId: 'goal-123',
+        creditsObtained: 100,
+        seasonId: 1,
+        weekNumber: 3
       }
     }
 
@@ -18,23 +20,55 @@ describe('CreditsGoalCompleted Events tests', () => {
     expect(CreditsGoalCompletedEvent.validate(null)).toEqual(false)
     expect(CreditsGoalCompletedEvent.validate({})).toEqual(false)
   })
-})
 
-describe('CreditsGoalCompletedEvent Events tests', () => {
-  it('CreditsGoalCompletedEvent static tests must pass', () => {
+  it('CreditsGoalCompletedEvent should fail with invalid creditsObtained', () => {
     const event: CreditsGoalCompletedEvent = {
       type: Events.Type.CREDITS_SERVICE,
       subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED,
-      key: 'key',
-      timestamp: 1,
+      key: 'goal-completion-123',
+      timestamp: 1710234567890,
       metadata: {
-        goalId: 'baf',
-        creditsAmount: 1
+        goalId: 'goal-123',
+        creditsObtained: -1, // Invalid negative amount
+        seasonId: 1,
+        weekNumber: 3
       }
     }
 
-    expect(CreditsGoalCompletedEvent.validate(event)).toEqual(true)
-    expect(CreditsGoalCompletedEvent.validate(null)).toEqual(false)
-    expect(CreditsGoalCompletedEvent.validate({})).toEqual(false)
+    expect(CreditsGoalCompletedEvent.validate(event)).toEqual(false)
+  })
+
+  it('CreditsGoalCompletedEvent should fail with invalid seasonId', () => {
+    const event: CreditsGoalCompletedEvent = {
+      type: Events.Type.CREDITS_SERVICE,
+      subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED,
+      key: 'goal-completion-123',
+      timestamp: 1710234567890,
+      metadata: {
+        goalId: 'goal-123',
+        creditsObtained: 100,
+        seasonId: 0, // Invalid season number
+        weekNumber: 3
+      }
+    }
+
+    expect(CreditsGoalCompletedEvent.validate(event)).toEqual(false)
+  })
+
+  it('CreditsGoalCompletedEvent should fail with invalid weekNumber', () => {
+    const event: CreditsGoalCompletedEvent = {
+      type: Events.Type.CREDITS_SERVICE,
+      subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED,
+      key: 'goal-completion-123',
+      timestamp: 1710234567890,
+      metadata: {
+        goalId: 'goal-123',
+        creditsObtained: 100,
+        seasonId: 1,
+        weekNumber: 0 // Invalid week number
+      }
+    }
+
+    expect(CreditsGoalCompletedEvent.validate(event)).toEqual(false)
   })
 })

--- a/test/platform/events/credits.spec.ts
+++ b/test/platform/events/credits.spec.ts
@@ -12,7 +12,8 @@ describe('Credits Events tests', () => {
         goalId: 'goal-123',
         creditsObtained: 100,
         seasonId: 1,
-        weekNumber: 3
+        weekNumber: 3,
+        userAddress: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
       }
     }
 
@@ -31,7 +32,8 @@ describe('Credits Events tests', () => {
         goalId: 'goal-123',
         creditsObtained: -1, // Invalid negative amount
         seasonId: 1,
-        weekNumber: 3
+        weekNumber: 3,
+        userAddress: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
       }
     }
 
@@ -48,7 +50,8 @@ describe('Credits Events tests', () => {
         goalId: 'goal-123',
         creditsObtained: 100,
         seasonId: 0, // Invalid season number
-        weekNumber: 3
+        weekNumber: 3,
+        userAddress: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
       }
     }
 
@@ -65,7 +68,26 @@ describe('Credits Events tests', () => {
         goalId: 'goal-123',
         creditsObtained: 100,
         seasonId: 1,
-        weekNumber: 0 // Invalid week number
+        weekNumber: 0, // Invalid week number
+        userAddress: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5'
+      }
+    }
+
+    expect(CreditsGoalCompletedEvent.validate(event)).toEqual(false)
+  })
+
+  it('CreditsGoalCompletedEvent should fail with missing userAddress', () => {
+    const event: any = {
+      type: Events.Type.CREDITS_SERVICE,
+      subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED,
+      key: 'goal-completion-123',
+      timestamp: 1710234567890,
+      metadata: {
+        goalId: 'goal-123',
+        creditsObtained: 100,
+        seasonId: 1,
+        weekNumber: 3
+        // userAddress missing
       }
     }
 

--- a/test/platform/events/credits.spec.ts
+++ b/test/platform/events/credits.spec.ts
@@ -1,0 +1,42 @@
+import expect from 'expect'
+import { CreditsGoalCompletedEvent, Events } from '../../../src'
+
+describe('CreditsGoalCompleted Events tests', () => {
+  it('CreditsGoalCompletedEvent static tests must pass', () => {
+    const event: CreditsGoalCompletedEvent = {
+      type: Events.Type.CREDITS_SERVICE,
+      subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED,
+      key: 'key',
+      timestamp: 1,
+      metadata: {
+        goalId: 'baf',
+        goalTitle: 'mac',
+        creditsAmount: 1
+      }
+    }
+
+    expect(CreditsGoalCompletedEvent.validate(event)).toEqual(true)
+    expect(CreditsGoalCompletedEvent.validate(null)).toEqual(false)
+    expect(CreditsGoalCompletedEvent.validate({})).toEqual(false)
+  })
+})
+
+describe('CreditsGoalCompletedEvent Events tests', () => {
+  it('CreditsGoalCompletedEvent static tests must pass', () => {
+    const event: CreditsGoalCompletedEvent = {
+      type: Events.Type.CREDITS_SERVICE,
+      subType: Events.SubType.CreditsService.CREDITS_GOAL_COMPLETED,
+      key: 'key',
+      timestamp: 1,
+      metadata: {
+        goalId: 'baf',
+        goalTitle: 'mac',
+        creditsAmount: 1
+      }
+    }
+
+    expect(CreditsGoalCompletedEvent.validate(event)).toEqual(true)
+    expect(CreditsGoalCompletedEvent.validate(null)).toEqual(false)
+    expect(CreditsGoalCompletedEvent.validate({})).toEqual(false)
+  })
+})


### PR DESCRIPTION
This PR exposes the events to be emitted by the `credits-server` about Credits granted. As of now, the need for this event is to send notifications in-world to users who have obtained credits.