### PR TITLE
fix: Rename photo privacy event name

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1487,7 +1487,7 @@ export namespace EthAddress {
 // Warning: (ae-missing-release-tag) "Event" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type Event = BadgeGrantedEvent | BidAcceptedEvent | BidReceivedEvent | CampaignGasPriceHigherThanExpectedEvent | CampaignOutOfFundsEvent | CampaignOutOfStockEvent | CatalystDeploymentEvent | CollectionCreatedEvent | FriendshipRequestEvent | FriendshipAcceptedEvent | ItemPublishedEvent | ItemSoldEvent | LoggedInEvent | LoggedInCachedEvent | MoveToParcelEvent | PassportOpenedEvent | RentalEndedEvent | RentalStartedEvent | RewardAssignedEvent | RewardDelayedEvent | RewardInProgressEvent | RoyaltiesEarnedEvent | UsedEmoteEvent | VerticalHeightReachedEvent | WalkedDistanceEvent | CreditsGoalCompletedEvent | StreamingKeyResetEvent | StreamingKeyRevokeEvent | StreamingKeyExpiredEvent | StreamingTimeExceededEvent | StreamingPlaceUpdatedEvent | UserJoinedRoomEvent | UserLeftRoomEvent | CreditsCompleteGoalsReminderEvent | CreditsUsageReminderEvent | CreditsUsage24HoursReminderEvent | CreditsDoNotMissOutReminderEvent | CreditsClaimReminderEvent | ReferralInvitedUsersAcceptedEvent | ReferralNewTierReachedEvent | CommunityDeletedEvent | CommunityDeletedContentViolationEvent | CommunityRenamedEvent | CommunityMemberBannedEvent | CommunityMemberRemovedEvent | CommunityRequestToJoinReceivedEvent | CommunityRequestToJoinAcceptedEvent | CommunityInviteReceivedEvent | PhotoTakenEvent | PhotoPrivacyChanged;
+export type Event = BadgeGrantedEvent | BidAcceptedEvent | BidReceivedEvent | CampaignGasPriceHigherThanExpectedEvent | CampaignOutOfFundsEvent | CampaignOutOfStockEvent | CatalystDeploymentEvent | CollectionCreatedEvent | FriendshipRequestEvent | FriendshipAcceptedEvent | ItemPublishedEvent | ItemSoldEvent | LoggedInEvent | LoggedInCachedEvent | MoveToParcelEvent | PassportOpenedEvent | RentalEndedEvent | RentalStartedEvent | RewardAssignedEvent | RewardDelayedEvent | RewardInProgressEvent | RoyaltiesEarnedEvent | UsedEmoteEvent | VerticalHeightReachedEvent | WalkedDistanceEvent | CreditsGoalCompletedEvent | StreamingKeyResetEvent | StreamingKeyRevokeEvent | StreamingKeyExpiredEvent | StreamingTimeExceededEvent | StreamingPlaceUpdatedEvent | UserJoinedRoomEvent | UserLeftRoomEvent | CreditsCompleteGoalsReminderEvent | CreditsUsageReminderEvent | CreditsUsage24HoursReminderEvent | CreditsDoNotMissOutReminderEvent | CreditsClaimReminderEvent | ReferralInvitedUsersAcceptedEvent | ReferralNewTierReachedEvent | CommunityDeletedEvent | CommunityDeletedContentViolationEvent | CommunityRenamedEvent | CommunityMemberBannedEvent | CommunityMemberRemovedEvent | CommunityRequestToJoinReceivedEvent | CommunityRequestToJoinAcceptedEvent | CommunityInviteReceivedEvent | PhotoTakenEvent | PhotoPrivacyChangedEvent;
 
 // Warning: (ae-missing-release-tag) "Events" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3004,11 +3004,11 @@ export namespace PeriodCreation {
     validate: ValidateFunction<PeriodCreation>;
 }
 
-// Warning: (ae-missing-release-tag) "PhotoPrivacyChanged" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "PhotoPrivacyChanged" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PhotoPrivacyChangedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PhotoPrivacyChangedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type PhotoPrivacyChanged = BaseEvent & {
+export type PhotoPrivacyChangedEvent = BaseEvent & {
     type: Events.Type.CAMERA;
     subType: Events.SubType.Camera.PHOTO_PRIVACY_CHANGED;
     metadata: {
@@ -3019,11 +3019,11 @@ export type PhotoPrivacyChanged = BaseEvent & {
 };
 
 // @public (undocumented)
-export namespace PhotoPrivacyChanged {
+export namespace PhotoPrivacyChangedEvent {
     const // (undocumented)
-    schema: JSONSchema<PhotoPrivacyChanged>;
+    schema: JSONSchema<PhotoPrivacyChangedEvent>;
     const // (undocumented)
-    validate: ValidateFunction<PhotoPrivacyChanged>;
+    validate: ValidateFunction<PhotoPrivacyChangedEvent>;
 }
 
 // Warning: (ae-missing-release-tag) "PhotoTakenEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/platform/events/base.ts
+++ b/src/platform/events/base.ts
@@ -29,7 +29,7 @@ import {
   CommunityRequestToJoinReceivedEvent
 } from './communities'
 import { BidReceivedEvent } from './marketplace'
-import { PhotoPrivacyChanged, PhotoTakenEvent } from './camera'
+import { PhotoPrivacyChangedEvent, PhotoTakenEvent } from './camera'
 import { ReferralInvitedUsersAcceptedEvent, ReferralNewTierReachedEvent } from './referral'
 import {
   RewardInProgressEvent,
@@ -254,4 +254,4 @@ export type Event =
   | CommunityRequestToJoinAcceptedEvent
   | CommunityInviteReceivedEvent
   | PhotoTakenEvent
-  | PhotoPrivacyChanged
+  | PhotoPrivacyChangedEvent

--- a/src/platform/events/camera.ts
+++ b/src/platform/events/camera.ts
@@ -14,7 +14,7 @@ export type PhotoTakenEvent = BaseEvent & {
   }
 }
 
-export type PhotoPrivacyChanged = BaseEvent & {
+export type PhotoPrivacyChangedEvent = BaseEvent & {
   type: Events.Type.CAMERA
   subType: Events.SubType.Camera.PHOTO_PRIVACY_CHANGED
   metadata: {
@@ -24,8 +24,8 @@ export type PhotoPrivacyChanged = BaseEvent & {
   }
 }
 
-export namespace PhotoPrivacyChanged {
-  export const schema: JSONSchema<PhotoPrivacyChanged> = {
+export namespace PhotoPrivacyChangedEvent {
+  export const schema: JSONSchema<PhotoPrivacyChangedEvent> = {
     type: 'object',
     properties: {
       type: { type: 'string', const: Events.Type.CAMERA },
@@ -46,7 +46,7 @@ export namespace PhotoPrivacyChanged {
     additionalProperties: false
   }
 
-  export const validate: ValidateFunction<PhotoPrivacyChanged> = generateLazyValidator(schema)
+  export const validate: ValidateFunction<PhotoPrivacyChangedEvent> = generateLazyValidator(schema)
 }
 
 export namespace PhotoTakenEvent {


### PR DESCRIPTION
This PR renames the photo privacy change event which was incorrectly named.