### PR TITLE
fix: Emote data discriminator

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1374,7 +1374,6 @@ export namespace EmoteCategory {
 // @public (undocumented)
 export type EmoteClip = {
     animation: string;
-    loop: boolean;
 };
 
 // @public (undocumented)
@@ -3005,7 +3004,9 @@ export enum OrderSortBy {
 // @public (undocumented)
 export type OutcomeGroup = {
     title: string;
+    loop: boolean;
     clips: Partial<Record<ArmatureId, EmoteClip>>;
+    audio?: string;
 };
 
 // @public (undocumented)
@@ -4206,8 +4207,10 @@ export type StandardProps = {
 //
 // @public (undocumented)
 export type StartAnimation = {
+    loop: boolean;
     [ArmatureId.Armature]: EmoteClip;
     [ArmatureId.Armature_Prop]?: EmoteClip;
+    audio?: string;
 };
 
 // @public (undocumented)

--- a/src/platform/item/emote/adr287/emote-data-adr287.ts
+++ b/src/platform/item/emote/adr287/emote-data-adr287.ts
@@ -18,7 +18,7 @@ export namespace ArmatureId {
 
 export type EmoteClip = {
   animation: string // GLB clip name (e.g., "HighFive_Avatar")
-  loop: boolean
+  sound?: string // Sound clip name (e.g., "HighFive_Avatar.ogg")
 }
 
 export namespace EmoteClip {
@@ -29,18 +29,20 @@ export namespace EmoteClip {
         type: 'string',
         minLength: 1
       },
-      loop: {
-        type: 'boolean'
+      sound: {
+        type: 'string',
+        nullable: true
       }
     },
-    required: ['animation', 'loop'],
-    additionalProperties: false
+    required: ['animation'],
+    additionalProperties: true
   }
 
   export const validate: ValidateFunction<EmoteClip> = generateLazyValidator(schema)
 }
 
 export type StartAnimation = {
+  loop: boolean
   [ArmatureId.Armature]: EmoteClip
   [ArmatureId.Armature_Prop]?: EmoteClip
 }
@@ -49,19 +51,23 @@ export namespace StartAnimation {
   export const schema: JSONSchema<StartAnimation> = {
     type: 'object',
     properties: {
+      loop: {
+        type: 'boolean'
+      },
       [ArmatureId.Armature]: EmoteClip.schema,
       [ArmatureId.Armature_Prop]: {
         ...EmoteClip.schema,
         nullable: true
       }
     },
-    required: [ArmatureId.Armature],
+    required: ['loop', ArmatureId.Armature],
     additionalProperties: true
   }
 }
 
 export type OutcomeGroup = {
   title: string
+  loop: boolean
   clips: Partial<Record<ArmatureId, EmoteClip>>
 }
 
@@ -72,6 +78,9 @@ export namespace OutcomeGroup {
       title: {
         type: 'string',
         minLength: 1
+      },
+      loop: {
+        type: 'boolean'
       },
       clips: {
         type: 'object',
@@ -86,7 +95,7 @@ export namespace OutcomeGroup {
         minProperties: 1
       }
     },
-    required: ['title', 'clips'],
+    required: ['title', 'loop', 'clips'],
     additionalProperties: false
   }
 

--- a/src/platform/item/emote/adr287/emote-data-adr287.ts
+++ b/src/platform/item/emote/adr287/emote-data-adr287.ts
@@ -27,15 +27,22 @@ export namespace EmoteClip {
     properties: {
       animation: {
         type: 'string',
-        minLength: 1
+        minLength: 1,
+        errorMessage: 'animation must be a non-empty string (GLB clip name)'
       },
       sound: {
         type: 'string',
-        nullable: true
+        nullable: true,
+        errorMessage: 'sound must be a string (sound clip name) when provided'
       }
     },
     required: ['animation'],
-    additionalProperties: true
+    additionalProperties: true,
+    errorMessage: {
+      required: {
+        animation: 'animation is required (GLB clip name)'
+      }
+    }
   }
 
   export const validate: ValidateFunction<EmoteClip> = generateLazyValidator(schema)
@@ -52,16 +59,27 @@ export namespace StartAnimation {
     type: 'object',
     properties: {
       loop: {
-        type: 'boolean'
+        type: 'boolean',
+        errorMessage: 'startAnimation.loop must be a boolean'
       },
-      [ArmatureId.Armature]: EmoteClip.schema,
+      [ArmatureId.Armature]: {
+        ...EmoteClip.schema,
+        errorMessage: 'startAnimation.Armature is required and must contain valid animation data'
+      },
       [ArmatureId.Armature_Prop]: {
         ...EmoteClip.schema,
-        nullable: true
+        nullable: true,
+        errorMessage: 'startAnimation.Armature_Prop must contain valid animation data when provided'
       }
     },
     required: ['loop', ArmatureId.Armature],
-    additionalProperties: true
+    additionalProperties: true,
+    errorMessage: {
+      required: {
+        loop: 'startAnimation.loop is required',
+        [ArmatureId.Armature]: 'startAnimation.Armature is required'
+      }
+    }
   }
 }
 
@@ -77,26 +95,37 @@ export namespace OutcomeGroup {
     properties: {
       title: {
         type: 'string',
-        minLength: 1
+        minLength: 1,
+        errorMessage: 'outcome.title must be a non-empty string'
       },
       loop: {
-        type: 'boolean'
+        type: 'boolean',
+        errorMessage: 'outcome.loop must be a boolean'
       },
       clips: {
         type: 'object',
         properties: Object.values(ArmatureId).reduce((properties, armature) => {
           properties[armature as ArmatureId] = {
             ...EmoteClip.schema,
-            nullable: true
+            nullable: true,
+            errorMessage: `outcome.clips.${armature} must contain valid animation data when provided`
           }
           return properties
         }, {} as Record<ArmatureId, typeof EmoteClip.schema & { nullable: true }>),
         additionalProperties: true,
-        minProperties: 1
+        minProperties: 1,
+        errorMessage: 'outcome.clips must contain at least one armature animation'
       }
     },
     required: ['title', 'loop', 'clips'],
-    additionalProperties: false
+    additionalProperties: false,
+    errorMessage: {
+      required: {
+        title: 'outcome.title is required',
+        loop: 'outcome.loop is required',
+        clips: 'outcome.clips is required'
+      }
+    }
   }
 
   export const validate: ValidateFunction<OutcomeGroup> = generateLazyValidator(schema)
@@ -115,19 +144,31 @@ export namespace EmoteDataADR287 {
       // Inherit all properties from EmoteDataADR74
       ...EmoteDataADR74.schema.properties,
       // Add ADR287-specific properties
-      startAnimation: StartAnimation.schema,
+      startAnimation: {
+        ...StartAnimation.schema,
+        errorMessage: 'emoteDataADR287.startAnimation is required and must contain valid start animation data'
+      },
       randomizeOutcomes: {
-        type: 'boolean'
+        type: 'boolean',
+        errorMessage: 'emoteDataADR287.randomizeOutcomes must be a boolean'
       },
       outcomes: {
         type: 'array',
         items: OutcomeGroup.schema,
         minItems: 1,
-        maxItems: 3
+        maxItems: 3,
+        errorMessage: 'emoteDataADR287.outcomes must be an array with 1-3 outcome groups'
       }
     },
     required: [...EmoteDataADR74.schema.required, 'startAnimation', 'randomizeOutcomes', 'outcomes'],
-    additionalProperties: true
+    additionalProperties: true,
+    errorMessage: {
+      required: {
+        startAnimation: 'emoteDataADR287.startAnimation is required for ADR287 emotes',
+        randomizeOutcomes: 'emoteDataADR287.randomizeOutcomes is required for ADR287 emotes',
+        outcomes: 'emoteDataADR287.outcomes is required for ADR287 emotes'
+      }
+    }
   }
 
   export const validate: ValidateFunction<EmoteDataADR287> = generateLazyValidator(schema)

--- a/src/platform/item/emote/adr287/emote-data-adr287.ts
+++ b/src/platform/item/emote/adr287/emote-data-adr287.ts
@@ -18,7 +18,6 @@ export namespace ArmatureId {
 
 export type EmoteClip = {
   animation: string // GLB clip name (e.g., "HighFive_Avatar")
-  sound?: string // Sound clip name (e.g., "HighFive_Avatar.ogg")
 }
 
 export namespace EmoteClip {
@@ -29,15 +28,10 @@ export namespace EmoteClip {
         type: 'string',
         minLength: 1,
         errorMessage: 'animation must be a non-empty string (GLB clip name)'
-      },
-      sound: {
-        type: 'string',
-        nullable: true,
-        errorMessage: 'sound must be a string (sound clip name) when provided'
       }
     },
     required: ['animation'],
-    additionalProperties: true,
+    additionalProperties: false,
     errorMessage: {
       required: {
         animation: 'animation is required (GLB clip name)'
@@ -52,6 +46,7 @@ export type StartAnimation = {
   loop: boolean
   [ArmatureId.Armature]: EmoteClip
   [ArmatureId.Armature_Prop]?: EmoteClip
+  audio?: string
 }
 
 export namespace StartAnimation {
@@ -70,6 +65,11 @@ export namespace StartAnimation {
         ...EmoteClip.schema,
         nullable: true,
         errorMessage: 'startAnimation.Armature_Prop must contain valid animation data when provided'
+      },
+      audio: {
+        type: 'string',
+        nullable: true,
+        errorMessage: 'audio must be a string (audio clip filename) when provided'
       }
     },
     required: ['loop', ArmatureId.Armature],
@@ -87,6 +87,7 @@ export type OutcomeGroup = {
   title: string
   loop: boolean
   clips: Partial<Record<ArmatureId, EmoteClip>>
+  audio?: string
 }
 
 export namespace OutcomeGroup {
@@ -115,6 +116,11 @@ export namespace OutcomeGroup {
         additionalProperties: true,
         minProperties: 1,
         errorMessage: 'outcome.clips must contain at least one armature animation'
+      },
+      audio: {
+        type: 'string',
+        nullable: true,
+        errorMessage: 'audio must be a string (audio clip filename) when provided'
       }
     },
     required: ['title', 'loop', 'clips'],

--- a/src/platform/item/emote/emote.ts
+++ b/src/platform/item/emote/emote.ts
@@ -67,7 +67,6 @@ export namespace Emote {
       errorMessage: { oneOf: 'emote should have either standard or thirdparty properties' }
     },
     else: {
-      // Si NO hay ADR287, exigimos ADR74
       required: ['emoteDataADR74'],
       prohibited: ['emoteDataADR287'],
       // ADR74: standard XOR thirdparty

--- a/src/platform/item/emote/emote.ts
+++ b/src/platform/item/emote/emote.ts
@@ -101,7 +101,7 @@ export namespace Emote {
       errorMessage: { oneOf: 'emote should have either standard or thirdparty properties' }
     },
     errorMessage: {
-      if: 'emote schema branching failed',
+      if: 'emote should have either "emoteDataADR74" or "emoteDataADR287" (but not both) and match its schema',
       then: 'emote should have "emoteDataADR287" and match its schema',
       else: 'emote should have "emoteDataADR74" and match its schema'
     }

--- a/src/platform/item/emote/emote.ts
+++ b/src/platform/item/emote/emote.ts
@@ -25,84 +25,86 @@ export namespace Emote {
     },
     additionalProperties: true,
     required: [...requiredBaseItemProps],
-    oneOf: [
+    allOf: [
       {
-        required: ['emoteDataADR74'],
-        prohibited: ['emoteDataADR287'],
-        // Emotes of ADR74 must be standard XOR thirdparty
-        oneOf: [
-          {
-            required: ['id', 'i18n'],
-            prohibited: ['merkleProof', 'content', 'collectionAddress', 'rarity'],
-            _isBaseEmote: true
-          },
-          {
-            required: ['collectionAddress', 'rarity'],
-            prohibited: ['merkleProof', 'content'],
-            errorMessage: 'standard properties conditions are not met'
-          },
-          {
-            required: [
-              'merkleProof',
-              /* MerkleProof emote required Keys (might be redundant) */
-              'content',
-              'id',
-              'name',
-              'description',
-              'i18n',
-              'image',
-              'thumbnail',
-              'emoteDataADR74'
-            ],
-            _isThirdParty: true,
-            prohibited: ['collectionAddress', 'rarity'],
-            errorMessage: 'thirdparty properties conditions are not met'
-          }
-        ],
-        errorMessage: {
-          oneOf: 'emote should have either standard or thirdparty properties'
-        }
-      },
-      {
-        required: ['emoteDataADR287'],
-        prohibited: ['emoteDataADR74'],
-        // Emotes of ADR287 must be standard XOR thirdparty
-        oneOf: [
-          {
-            required: ['id', 'i18n'],
-            prohibited: ['merkleProof', 'content', 'collectionAddress', 'rarity'],
-            _isBaseEmote: true
-          },
-          {
-            required: ['collectionAddress', 'rarity'],
-            prohibited: ['merkleProof', 'content'],
-            errorMessage: 'standard properties conditions are not met'
-          },
-          {
-            required: [
-              'merkleProof',
-              /* MerkleProof emote required Keys (might be redundant) */
-              'content',
-              'id',
-              'name',
-              'description',
-              'i18n',
-              'image',
-              'thumbnail',
-              'emoteDataADR287'
-            ],
-            _isThirdParty: true,
-            prohibited: ['collectionAddress', 'rarity'],
-            errorMessage: 'thirdparty properties conditions are not met'
-          }
-        ],
-        errorMessage: {
-          oneOf: 'emote should have either standard or thirdparty properties'
+        not: {
+          required: ['emoteDataADR74', 'emoteDataADR287']
         }
       }
     ],
+    if: { required: ['emoteDataADR287'] },
+    then: {
+      prohibited: ['emoteDataADR74'],
+      // ADR287: standard XOR thirdparty
+      oneOf: [
+        {
+          required: ['id', 'i18n'],
+          prohibited: ['merkleProof', 'content', 'collectionAddress', 'rarity'],
+          _isBaseEmote: true
+        },
+        {
+          required: ['collectionAddress', 'rarity'],
+          prohibited: ['merkleProof', 'content'],
+          errorMessage: 'standard properties conditions are not met'
+        },
+        {
+          required: [
+            'merkleProof',
+            'content',
+            'id',
+            'name',
+            'description',
+            'i18n',
+            'image',
+            'thumbnail',
+            'emoteDataADR287'
+          ],
+          _isThirdParty: true,
+          prohibited: ['collectionAddress', 'rarity'],
+          errorMessage: 'thirdparty properties conditions are not met'
+        }
+      ],
+      errorMessage: { oneOf: 'emote should have either standard or thirdparty properties' }
+    },
+    else: {
+      // Si NO hay ADR287, exigimos ADR74
+      required: ['emoteDataADR74'],
+      prohibited: ['emoteDataADR287'],
+      // ADR74: standard XOR thirdparty
+      oneOf: [
+        {
+          required: ['id', 'i18n'],
+          prohibited: ['merkleProof', 'content', 'collectionAddress', 'rarity'],
+          _isBaseEmote: true
+        },
+        {
+          required: ['collectionAddress', 'rarity'],
+          prohibited: ['merkleProof', 'content'],
+          errorMessage: 'standard properties conditions are not met'
+        },
+        {
+          required: [
+            'merkleProof',
+            'content',
+            'id',
+            'name',
+            'description',
+            'i18n',
+            'image',
+            'thumbnail',
+            'emoteDataADR74'
+          ],
+          _isThirdParty: true,
+          prohibited: ['collectionAddress', 'rarity'],
+          errorMessage: 'thirdparty properties conditions are not met'
+        }
+      ],
+      errorMessage: { oneOf: 'emote should have either standard or thirdparty properties' }
+    },
     errorMessage: {
-      oneOf: 'emote should have either "emoteDataADR74" or "emoteDataADR287" (but not both) and match its schema'
+      if: 'emote schema branching failed',
+      then: 'emote should have "emoteDataADR287" and match its schema',
+      else: 'emote should have "emoteDataADR74" and match its schema'
     }
   }
 

--- a/test/platform/item/emote/emote.spec.ts
+++ b/test/platform/item/emote/emote.spec.ts
@@ -1,6 +1,14 @@
 import expect from 'expect'
 import { Rarity, EmoteCategory } from '../../../../src'
-import { Locale, BodyShape, Emote, EmoteRepresentationADR74, isStandard, isThirdParty } from '../../../../src'
+import {
+  Locale,
+  BodyShape,
+  Emote,
+  EmoteRepresentationADR74,
+  isStandard,
+  isThirdParty,
+  ArmatureId
+} from '../../../../src'
 import { expectValidationFailureWithErrors, testTypeSignature } from '../../../test-utils'
 
 describe('Emote tests', () => {
@@ -29,6 +37,31 @@ describe('Emote tests', () => {
     representations: [representation],
     tags: ['tag1'],
     loop: false
+  }
+
+  const emoteDataADR287 = {
+    category: EmoteCategory.DANCE,
+    representations: [representation],
+    tags: ['tag1'],
+    loop: false,
+    startAnimation: {
+      loop: true,
+      [ArmatureId.Armature]: {
+        animation: 'HighFive_Avatar'
+      }
+    },
+    randomizeOutcomes: false,
+    outcomes: [
+      {
+        title: 'HighFive',
+        loop: false,
+        clips: {
+          [ArmatureId.Armature]: {
+            animation: 'HighFive_Avatar'
+          }
+        }
+      }
+    ]
   }
 
   const standardProps = {
@@ -67,6 +100,37 @@ describe('Emote tests', () => {
     }
   }
 
+  const thirdPartyPropsADR287 = {
+    content: {
+      'thumbnail.png': 'someHash',
+      'iamge.png': 'someOtherHash'
+    },
+    merkleProof: {
+      index: 61575,
+      proof: [
+        '0xc8ae2407cffddd38e3bcb6c6f021c9e7ac21fcc60be44e76e4afcb34f637d562',
+        '0x16123d205a70cdeff7643de64cdc69a0517335d9c843479e083fd444ea823172',
+        '0x1fbe73f1e71f11fb4e88de5404f3177673bdfc89e93d9a496849b4ed32c9b04f',
+        '0xed60c527e6774dbf6750f7e28dbf93c25a22660085f709c3a0a772606768fd91',
+        '0x7aff1c982d6a98544c126a0676ac98102533072b6c4506f31b413757e38f4c30',
+        '0x5f5170cdf5fdd7bb25c225d08b48361e41f05477880812f7f5954e75daa6c667',
+        '0x08ae25d236fa4105b2c5136938bc42f55d339f8e4d9feb776799681b8a8a48e7',
+        '0xadfcc425df780be50983856c7de4d405a3ec054b74020628a9d13fdbaff35df7',
+        '0xda4ee1c4148a25eefbef12a92cc6a754c6312c1ff15c059f46e049ca4e5ca43b',
+        '0x98c363c32c7b1d7914332efaa19ad2bee7e110d79d7690650dbe7ce8ba1002a2',
+        '0x0bd810301fbafeb4848f7b60a378c9017a452286836d19a108812682edf8a12a',
+        '0x1533c6b3879f90b92fc97ec9a1db86f201623481b1e0dc0eefa387584c5d93da',
+        '0x31c2c3dbf88646a964edd88edb864b536182619a02905eaac2a00b0c5a6ae207',
+        '0xc2088dbbecba4f7dd06c689b7c1a1e6a822d20d4665b2f9353715fc3a5f0d588',
+        '0x9e191109e34d166ac72033dce274a82c488721a274087ae97b62c9a51944e86f',
+        '0x5ff2905107fe4cce21c93504414d9548f311cd27efe5696c0e03acc059d2e445',
+        '0x6c764a5d8ded16bf0b04028b5754afbd216b111fa0c9b10f2126ac2e9002e2fa'
+      ],
+      hashingKeys: ['id', 'name', 'description', 'i18n', 'image', 'thumbnail', 'emoteDataADR287', 'content'],
+      entityHash: '52c312f5e5524739388af971cddb526c3b49ba31ec77abc07ca01f5b113f1eba'
+    }
+  }
+
   const standardEmote = {
     ...baseEmote,
     ...standardProps,
@@ -77,12 +141,27 @@ describe('Emote tests', () => {
     ...thirdPartyProps,
     emoteDataADR74
   }
+
+  const standardEmoteADR287 = {
+    ...baseEmote,
+    ...standardProps,
+    emoteDataADR287
+  }
+  const thirdPartyEmoteADR287 = {
+    ...baseEmote,
+    ...thirdPartyPropsADR287,
+    emoteDataADR287
+  }
   testTypeSignature(Emote, standardEmote)
   testTypeSignature(Emote, thirdPartyEmote)
+  testTypeSignature(Emote, standardEmoteADR287)
+  testTypeSignature(Emote, thirdPartyEmoteADR287)
 
   it('static tests must pass', () => {
     expect(Emote.validate(standardEmote)).toEqual(true)
     expect(Emote.validate(thirdPartyEmote)).toEqual(true)
+    expect(Emote.validate(standardEmoteADR287)).toEqual(true)
+    expect(Emote.validate(thirdPartyEmoteADR287)).toEqual(true)
     expect(Emote.validate(null)).toEqual(false)
     expect(Emote.validate({})).toEqual(false)
   })
@@ -145,6 +224,19 @@ describe('Emote tests', () => {
     )
   })
 
+  it('emote with both emoteDataADR74 and emoteDataADR287 fails', () => {
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR74,
+        emoteDataADR287
+      },
+      ['emote should have either "emoteDataADR74" or "emoteDataADR287" (but not both) and match its schema']
+    )
+  })
+
   it('emote should be standard and/or thirdparty', () => {
     expectValidationFailureWithErrors(
       Emote.validate,
@@ -167,6 +259,14 @@ describe('Emote tests', () => {
 
   it('emote with thirdparty props is thirdParty', () => {
     expect(isThirdParty(thirdPartyEmote)).toBeTruthy()
+  })
+
+  it('emote with standard props and ADR287 is standard', () => {
+    expect(isStandard(standardEmoteADR287)).toBeTruthy()
+  })
+
+  it('emote with thirdparty props and ADR287 is thirdParty', () => {
+    expect(isThirdParty(thirdPartyEmoteADR287)).toBeTruthy()
   })
 
   it('group of properties must be complete, not partial', () => {
@@ -241,7 +341,6 @@ describe('Emote tests', () => {
         entityHash: '52c312f5e5524739388af971cddb526c3b49ba31ec77abc07ca01f5b113f1eba'
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { image, ...baseEmoteWithoutImage } = baseEmote
     const notThirdPartyEmote = {
       ...baseEmoteWithoutImage,
@@ -251,5 +350,446 @@ describe('Emote tests', () => {
     expectValidationFailureWithErrors(Emote.validate, notThirdPartyEmote, [
       'thirdparty properties conditions are not met'
     ])
+  })
+
+  it('emote with ADR287 should have either standard or thirdparty properties', () => {
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        emoteDataADR287
+      },
+      [
+        'standard properties conditions are not met',
+        'thirdparty properties conditions are not met',
+        'emote should have either standard or thirdparty properties'
+      ]
+    )
+  })
+
+  it('emote with ADR287 and merkle proof and standard fields fails', () => {
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        ...thirdPartyProps,
+        emoteDataADR287
+      },
+      [
+        'standard properties conditions are not met',
+        'thirdparty properties conditions are not met',
+        'emote should have either standard or thirdparty properties'
+      ]
+    )
+  })
+
+  it('emote with ADR287 and incomplete standard properties fails', () => {
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        collectionAddress: '0x...',
+        emoteDataADR287
+      },
+      [
+        'standard properties conditions are not met',
+        'thirdparty properties conditions are not met',
+        'emote should have either standard or thirdparty properties'
+      ]
+    )
+  })
+
+  it('thirdparty emote with ADR287 and not all hashing keys present fails', () => {
+    const notValidThirdPartyPropsADR287 = {
+      content: {
+        'thumbnail.png': 'someHash'
+      },
+      merkleProof: {
+        index: 61575,
+        proof: [
+          '0xc8ae2407cffddd38e3bcb6c6f021c9e7ac21fcc60be44e76e4afcb34f637d562',
+          '0x16123d205a70cdeff7643de64cdc69a0517335d9c843479e083fd444ea823172'
+        ],
+        hashingKeys: [
+          'id',
+          'name',
+          'description',
+          'i18n',
+          'image',
+          'thumbnail',
+          'emoteDataADR287',
+          'content',
+          'notPresentKey'
+        ],
+        entityHash: '52c312f5e5524739388af971cddb526c3b49ba31ec77abc07ca01f5b113f1eba'
+      }
+    }
+    const notThirdPartyEmoteADR287 = {
+      ...baseEmote,
+      ...notValidThirdPartyPropsADR287,
+      emoteDataADR287
+    }
+    expectValidationFailureWithErrors(Emote.validate, notThirdPartyEmoteADR287, [
+      'standard properties conditions are not met',
+      'thirdparty properties conditions are not met',
+      'emote should have either standard or thirdparty properties'
+    ])
+    expect(isThirdParty(notThirdPartyEmoteADR287)).toEqual(false)
+  })
+
+  it('thirdparty emote with ADR287 contain all hashing keys but does not have all the required ones', () => {
+    const thirdPartyPropsMissingImageADR287 = {
+      content: {
+        'thumbnail.png': 'someHash'
+      },
+      merkleProof: {
+        index: 61575,
+        proof: [
+          '0xc8ae2407cffddd38e3bcb6c6f021c9e7ac21fcc60be44e76e4afcb34f637d562',
+          '0x16123d205a70cdeff7643de64cdc69a0517335d9c843479e083fd444ea823172'
+        ],
+        hashingKeys: ['id', 'name', 'description', 'i18n', 'thumbnail', 'emoteDataADR287', 'content'],
+        entityHash: '52c312f5e5524739388af971cddb526c3b49ba31ec77abc07ca01f5b113f1eba'
+      }
+    }
+
+    const { image, ...baseEmoteWithoutImage } = baseEmote
+    const notThirdPartyEmoteADR287 = {
+      ...baseEmoteWithoutImage,
+      ...thirdPartyPropsMissingImageADR287,
+      emoteDataADR287
+    }
+    expectValidationFailureWithErrors(Emote.validate, notThirdPartyEmoteADR287, [
+      'thirdparty properties conditions are not met'
+    ])
+  })
+
+  it('emote with ADR287 and missing startAnimation fails', () => {
+    const { startAnimation, ...invalidEmoteDataADR287 } = emoteDataADR287
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['emoteDataADR287.startAnimation is required for ADR287 emotes']
+    )
+  })
+
+  it('emote with ADR287 and startAnimation without required armature fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      startAnimation: {
+        loop: true
+      }
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['emoteDataADR287.startAnimation is required and must contain valid start animation data']
+    )
+  })
+
+  it('emote with ADR287 and startAnimation with additional armature properties is valid', () => {
+    const validEmoteDataADR287 = {
+      ...emoteDataADR287,
+      startAnimation: {
+        loop: true,
+        [ArmatureId.Armature]: {
+          animation: 'HighFive_Avatar'
+        },
+        InvalidArmature: {
+          animation: 'Invalid_Avatar'
+        }
+      }
+    }
+
+    expect(
+      Emote.validate({
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: validEmoteDataADR287
+      })
+    ).toEqual(true)
+  })
+
+  it('emote with ADR287 and missing outcomes fails', () => {
+    const { outcomes, ...invalidEmoteDataADR287 } = emoteDataADR287
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['emoteDataADR287.outcomes is required for ADR287 emotes']
+    )
+  })
+
+  it('emote with ADR287 and empty outcomes fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      outcomes: []
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['emoteDataADR287.outcomes must be an array with 1-3 outcome groups']
+    )
+  })
+
+  it('emote with ADR287 and more than 3 outcomes fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      outcomes: [
+        {
+          title: 'Outcome1',
+          loop: false,
+          clips: {
+            [ArmatureId.Armature]: {
+              animation: 'Outcome1_Avatar'
+            }
+          }
+        },
+        {
+          title: 'Outcome2',
+          loop: false,
+          clips: {
+            [ArmatureId.Armature]: {
+              animation: 'Outcome2_Avatar'
+            }
+          }
+        },
+        {
+          title: 'Outcome3',
+          loop: false,
+          clips: {
+            [ArmatureId.Armature]: {
+              animation: 'Outcome3_Avatar'
+            }
+          }
+        },
+        {
+          title: 'Outcome4',
+          loop: false,
+          clips: {
+            [ArmatureId.Armature]: {
+              animation: 'Outcome4_Avatar'
+            }
+          }
+        }
+      ]
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['emoteDataADR287.outcomes must be an array with 1-3 outcome groups']
+    )
+  })
+
+  it('emote with ADR287 and outcomes with additional armature properties is valid', () => {
+    const validEmoteDataADR287 = {
+      ...emoteDataADR287,
+      outcomes: [
+        {
+          title: 'HighFive',
+          loop: false,
+          clips: {
+            [ArmatureId.Armature]: {
+              animation: 'HighFive_Avatar'
+            },
+            InvalidArmature: {
+              animation: 'Invalid_Avatar'
+            }
+          }
+        }
+      ]
+    }
+
+    expect(
+      Emote.validate({
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: validEmoteDataADR287
+      })
+    ).toEqual(true)
+  })
+
+  it('emote with ADR287 and missing randomizeOutcomes fails', () => {
+    const { randomizeOutcomes, ...invalidEmoteDataADR287 } = emoteDataADR287
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['emoteDataADR287.randomizeOutcomes is required for ADR287 emotes']
+    )
+  })
+
+  it('emote with ADR287 and invalid randomizeOutcomes type fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      randomizeOutcomes: 'true' // Should be boolean, not string
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['emoteDataADR287.randomizeOutcomes must be a boolean']
+    )
+  })
+
+  it('emote with ADR287 and outcome without required title fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      outcomes: [
+        {
+          // Missing title
+          loop: false,
+          clips: {
+            [ArmatureId.Armature]: {
+              animation: 'HighFive_Avatar'
+            }
+          }
+        }
+      ]
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['outcome.title is required']
+    )
+  })
+
+  it('emote with ADR287 and outcome without required clips fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      outcomes: [
+        {
+          title: 'HighFive',
+          loop: false
+          // Missing clips
+        }
+      ]
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['outcome.clips is required']
+    )
+  })
+
+  it('emote with ADR287 and outcome with empty clips fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      outcomes: [
+        {
+          title: 'HighFive',
+          loop: false,
+          clips: {}
+        }
+      ]
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['outcome.clips must contain at least one armature animation']
+    )
+  })
+
+  it('emote with ADR287 and outcome clip without animation fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      outcomes: [
+        {
+          title: 'HighFive',
+          loop: false,
+          clips: {
+            [ArmatureId.Armature]: {
+              // Missing animation
+              sound: 'HighFive_Avatar.ogg'
+            }
+          }
+        }
+      ]
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['outcome.clips.Armature must contain valid animation data when provided']
+    )
+  })
+
+  it('emote with ADR287 and outcome clip with empty animation fails', () => {
+    const invalidEmoteDataADR287 = {
+      ...emoteDataADR287,
+      outcomes: [
+        {
+          title: 'HighFive',
+          loop: false,
+          clips: {
+            [ArmatureId.Armature]: {
+              animation: '' // Empty string should fail
+            }
+          }
+        }
+      ]
+    }
+
+    expectValidationFailureWithErrors(
+      Emote.validate,
+      {
+        ...baseEmote,
+        ...standardProps,
+        emoteDataADR287: invalidEmoteDataADR287
+      },
+      ['animation must be a non-empty string (GLB clip name)']
+    )
   })
 })


### PR DESCRIPTION
This PR fixes the Emote schema to support the new emoteDataADR287 version while keeping backward compatibility with emoteDataADR74.